### PR TITLE
Reduced docker image size and added CronTask

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,9 +15,9 @@ RUN apt-get update \
 
 RUN mkdir -p /var/www/html/cache /var/www/html/utils
 COPY index.php /var/www/html/index.php
-COPY clean.php /var/www/html/utils/clean.php
+COPY clean.php /var/www/html/clean.php
 COPY .htaccess /var/www/html/.htaccess
-COPY constants.php /var/www/html/utils/constants.php
+COPY constants.php /var/www/html/constants.php
 COPY composer.json /var/www/html/composer.json
 COPY docker/apache.conf  /etc/apache2/conf-available/apache.conf
 RUN touch /var/log/cron.log
@@ -33,7 +33,7 @@ WORKDIR /var/www/html
 
 RUN composer install
  
-RUN echo "0 0 * * 0  root /usr/local/bin/php var/www/html/utils/clean.php >> /var/log/cron.log 2>&1" >> /etc/crontab
+RUN echo "0 0 * * 0  root /usr/local/bin/php var/www/html/clean.php >> /var/log/cron.log 2>&1" >> /etc/crontab
 
 EXPOSE 80
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,9 +17,10 @@ RUN mkdir -p /var/www/html/cache /var/www/html/utils
 COPY index.php /var/www/html/index.php
 COPY clean.php /var/www/html/utils/clean.php
 COPY .htaccess /var/www/html/.htaccess
-COPY constants.php /var/www/html/constants.php
+COPY constants.php /var/www/html/utils/constants.php
 COPY composer.json /var/www/html/composer.json
 COPY docker/apache.conf  /etc/apache2/conf-available/apache.conf
+RUN touch /var/log/cron.log
 
 RUN chown -R www-data:www-data /var/www/html/cache && \
 	chmod -R 775 /var/www/html/cache
@@ -31,8 +32,9 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 WORKDIR /var/www/html
 
 RUN composer install
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"] 
-RUN echo "0 0 * * 0 www-data php /var/www/html/utils/clean.php >> /var/log/cron.log 2>&1" | crontab -u www-data -
+ 
+RUN echo "0 0 * * 0  root /usr/local/bin/php var/www/html/utils/clean.php >> /var/log/cron.log 2>&1" >> /etc/crontab
 
 EXPOSE 80
+
+CMD service cron start && /usr/local/bin/apache2-foreground

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,17 @@
 FROM php:8.2-apache
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
 	libfreetype6-dev \
 	libjpeg62-turbo-dev \
 	libpng-dev \
 	zip \
 	unzip \
 	git \
+	cron \
 	&& docker-php-ext-configure gd --with-freetype --with-jpeg \
-	&& docker-php-ext-install -j$(nproc) gd
+	&& docker-php-ext-install -j$(nproc) gd \
+	&& apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /var/www/html/cache /var/www/html/utils
 COPY index.php /var/www/html/index.php
@@ -28,5 +31,8 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 WORKDIR /var/www/html
 
 RUN composer install
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"] 
+RUN echo "0 0 * * 0 www-data php /var/www/html/utils/clean.php >> /var/log/cron.log 2>&1" | crontab -u www-data -
 
 EXPOSE 80

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update \
 	&& docker-php-ext-install -j$(nproc) gd \
 	&& apt-get clean && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /var/www/html/cache /var/www/html/utils
+RUN mkdir -p /var/www/html/cache
 COPY index.php /var/www/html/index.php
 COPY clean.php /var/www/html/clean.php
 COPY .htaccess /var/www/html/.htaccess


### PR DESCRIPTION
1. **Size Optimization:**
   - Reduced the Docker image size by clearing the apt cache and excluding the installation of recommended packages.
     - *Previous Image Size:* 836MB
     - *New Image Size:* 787MB

2. **Cron:**
   - Added cron task scheduled to execute `clean.php` weekly like you suggested.


*sorry for the multiple commits..*
