### PR TITLE
Fix composer dependencies and lint dockerfile

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
         "guzzlehttp/guzzle": "*",
-        "intervention/image": "*"
+        "intervention/image": "2.7.2"
     }
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM php:8.2-apache
+# hadolint ignore=DL3007
+FROM composer:latest AS composer
+FROM php:8.3-apache
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends \
@@ -10,7 +12,7 @@ RUN apt-get update \
 	git \
 	cron \
 	&& docker-php-ext-configure gd --with-freetype --with-jpeg \
-	&& docker-php-ext-install -j$(nproc) gd \
+	&& docker-php-ext-install -j"$(nproc)" gd \
 	&& apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /var/www/html/cache
@@ -20,21 +22,19 @@ COPY .htaccess /var/www/html/.htaccess
 COPY constants.php /var/www/html/constants.php
 COPY composer.json /var/www/html/composer.json
 COPY docker/apache.conf  /etc/apache2/conf-available/apache.conf
-RUN touch /var/log/cron.log
 
 RUN chown -R www-data:www-data /var/www/html/cache && \
-	chmod -R 775 /var/www/html/cache
+	chmod -R 775 /var/www/html/cache && \
+	echo "0 0 * * 0  www-data /usr/local/bin/php /var/www/html/clean.php >> /var/log/cron.log 2>&1" >> /etc/crontab
 
 RUN a2enconf apache
 
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 WORKDIR /var/www/html
 
-RUN composer install
- 
-RUN echo "0 0 * * 0  root /usr/local/bin/php /var/www/html/clean.php >> /var/log/cron.log 2>&1" >> /etc/crontab
+RUN composer install --optimize-autoloader
 
 EXPOSE 80
 
-CMD service cron start && /usr/local/bin/apache2-foreground
+CMD ["sh", "-c", "service cron start && /usr/local/bin/apache2-foreground"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,6 +5,8 @@ services:
         build: 
             context: ../
             dockerfile: docker/Dockerfile
+        container_name: statsfm-php
+        restart: unless-stopped
         ports:
             - "2812:80"
         volumes:


### PR DESCRIPTION
Hello, this PR introduces a fix for `intervention/image` dependency since v3+ has breaking changes and some updates in the Dockerfile. 

- Base image upgrade : `php 8.2` to `php 8.3`
- Some refactoring using Hadolint linter.